### PR TITLE
When the `options` prop changes on a `SelectField` with `multiple` se…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- When the `options` prop changes on a `SelectField` with `multiple` set to false, previously it was automatically performing the fuzzy filter on the options, which resulted in not all of the options being displayed. This is the correct behavior if the dropdown is open, but if it's closed we want to display all of the options.
+
 ## [16.2.1] - 2019-12-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+
+- The `useForm` hook is now exported.
+
 ### Changed
 
 - When the `options` prop changes on a `SelectField` with `multiple` set to false, previously it was automatically performing the fuzzy filter on the options, which resulted in not all of the options being displayed. This is the correct behavior if the dropdown is open, but if it's closed we want to display all of the options.

--- a/src/components.ts
+++ b/src/components.ts
@@ -41,7 +41,7 @@ export { default as ModalDialog } from "./components/modals/ModalDialog";
 export { default as BooleanField } from "./components/form/BooleanField";
 export { default as CentsField } from "./components/form/CentsField";
 export { default as DateTimeField } from "./components/form/DateTimeField";
-export { default as Form, withForm } from "./components/form/Form";
+export { default as Form, withForm, useForm } from "./components/form/Form";
 export { EmailField, NumberField, PasswordField, StringField } from "./components/form/FormFields";
 export { default as FileField } from "./components/form/FileField";
 export { default as ImageField } from "./components/form/ImageField";

--- a/src/components/form/select/SelectFieldSingle.tsx
+++ b/src/components/form/select/SelectFieldSingle.tsx
@@ -66,10 +66,10 @@ class SelectFieldSingle extends React.Component<SelectFieldSingleProps, SelectFi
     const { display } = this.state;
 
     if (prevProps.options !== options) {
-      this.setState({
+      this.setState(({ open }) => ({
         display: getDisplay(this.props),
-        filteredOptions: fuzzyFilter(options, display)
-      });
+        filteredOptions: open ? fuzzyFilter(options, display) : options
+      }));
     } else if (prevProps.value !== value && (!creatable || !display)) {
       this.setState({ display: getDisplay(this.props) });
     }


### PR DESCRIPTION
…t to false, previously it was automatically performing the fuzzy filter on the options, which resulted in not all of the options being displayed. This is the correct behavior if the dropdown is open, but if it's closed we want to display all of the options.