### PR TITLE
Add suffix icon to the email field v19.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [19.15.2] - 2024-04-10
+
+### Added
+
+- Added suffix icon to the email field
+
 ## [19.15.1] - 2024-04-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@culturehq/components",
-  "version": "19.15.1",
+  "version": "19.15.2",
   "description": "CultureHQ's component library",
   "main": "dist/components.js",
   "types": "dist/components.d.ts",

--- a/src/components/form/FormFields.tsx
+++ b/src/components/form/FormFields.tsx
@@ -7,6 +7,7 @@ import FormError from "./FormError";
 import { useForm } from "./Form";
 import { FormFieldError } from "./typings";
 import useDisabled from "./useDisabled";
+import Icon, { IconName } from "../Icon";
 
 type HijackedProps = "className" | "name" | "onChange" | "required" | "value";
 type FormFieldProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, HijackedProps> & {
@@ -19,12 +20,13 @@ type FormFieldProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, Hijacked
   required?: boolean;
   validator?: (value: string) => FormFieldError;
   value?: string;
+  suffixIcon?: IconName;
 };
 
 const makeFormField = (type: string) => {
   const FormField: React.FC<FormFieldProps> = ({
     addon, autoFocus, children, className, disabled, name, onChange, required,
-    validator, value, max, min, ...props
+    validator, value, max, min, suffixIcon, ...props
   }) => {
     const { submitted, values, onError, onFormChange } = useForm();
 
@@ -53,18 +55,24 @@ const makeFormField = (type: string) => {
       <label className={classnames("chq-ffd", className)} htmlFor={name}>
         <span className="chq-ffd--lb">{children}</span>
         {addon && <span className="chq-ffd--ad">{addon}</span>}
-        <input
-          className={`chq-ffd--ctrl ${max && "chq-ffd--ctrl--with-validation"}`}
-          ref={inputRef}
-          {...props}
-          disabled={disabled}
-          type={type}
-          id={name}
-          name={name}
-          value={normal || ""}
-          onBlur={onBlur}
-          onChange={handleChange}
-        />
+        <>
+          {suffixIcon && (
+            <Icon className="chq-ffd--sl--suffix-icon" icon={suffixIcon} />
+          ) }
+          <input
+            className={`chq-ffd--ctrl ${max && "chq-ffd--ctrl--with-validation"}`}
+            style={suffixIcon ? { paddingRight: "40px" } : {}}
+            ref={inputRef}
+            {...props}
+            disabled={disabled}
+            type={type}
+            id={name}
+            name={name}
+            value={normal || ""}
+            onBlur={onBlur}
+            onChange={handleChange}
+          />
+        </>
         {max && (<span className="chq-ffd--ctrl--validation">{min !== undefined ? min : normal?.length || 0}/{max}</span>)}
         <FormError
           name={name}

--- a/src/styles/components/_select-field.scss
+++ b/src/styles/components/_select-field.scss
@@ -75,10 +75,14 @@
     }
   }
 
-  &--icon {
+  &--icon, &--suffix-icon {
     max-width: 30px;
     padding: 5px;
     position: absolute;
+  }
+
+  &--suffix-icon {
+    right: 5px;
   }
 
   &--opts {

--- a/stories/form/EmailField.stories.tsx
+++ b/stories/form/EmailField.stories.tsx
@@ -43,4 +43,5 @@ storiesOf("Form/EmailField", module)
     return (
       <Container name="email" required validator={validator}>Email</Container>
     );
-  });
+  })
+  .add("suffix icon", () => <Container name="email" suffixIcon="linkedin-share">Email</Container>);


### PR DESCRIPTION
# Pull Request

## Description

Add suffix icon to the email field. If the suffixIcon property is provided, the suffix icon will be displayed at the right side of the email field.
Project Version: 19.15.2

Fixes [(ticket link)](https://trello.com/c/qUZHxhiE/2215-email-field-should-have-a-prop-to-add-an-suffix-icon)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Go to the suffix icon component
- Verify that the icon is displaying on the right side of the email field 
