### PR TITLE
Add functionality to disable future dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [20.2.1] - 2024-07-08
+
+## Added
+
+- Adding disable future dates to the `Calendar` component
+
 ## [20.2.0] - 2024-06-26
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@culturehq/components",
-  "version": "20.2.0",
+  "version": "20.2.1",
   "description": "CultureHQ's component library",
   "main": "dist/components.js",
   "types": "dist/components.d.ts",

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -68,11 +68,12 @@ type CalendarProps = {
   month2?: null | number;
   day2?: null | number;
   range?: boolean;
+  disable?: boolean;
   onChange: (year: number, month: number, day: number, range?: boolean) => void;
 };
 
 const Calendar: React.FC<CalendarProps> = ({ year = null, month = null, day = null,
-  onChange, range = false, year2, month2, day2 }) => {
+  onChange, range = false, year2, month2, day2, disable = false }) => {
   const [visible, setVisible] = useState<CalendarView>(() => ({
     year: year === null ? new Date().getFullYear() : year,
     month: month === null ? new Date().getMonth() : month
@@ -178,19 +179,21 @@ const Calendar: React.FC<CalendarProps> = ({ year = null, month = null, day = nu
       </div>
       <div className="chq-cal--days">
         {values.map(value => {
+          const today = new Date();
+          const currentDay = new Date(value.year, value.month, value.day);
           const valueHash = `${value.year}-${value.month}-${value.day}`;
           const onClick = () => onChange(value.year, value.month, value.day, range);
           const inRange = isInRange(value.year, value.month, value.day);
           const className = classnames("chq-cal--day", {
             "chq-cal--day-act": (valueHash === activeHash || valueHash === activeHash2),
-            "chq-cal--day-out": value.fill,
+            "chq-cal--day-out": value.fill || (today < currentDay && disable),
             "chq-cal--day-in-range": inRange
           });
 
           return (
             <>
               <div id={`${value.month}-${value.day}-${value.year}`} style={{ display: "none" }}>{monthNames[value.month]} {value.day}, {value.year}</div>
-              <PlainButton key={valueHash} className={className} onClick={onClick} aria-labelledby={`${value.month}-${value.day}-${value.year}`}>
+              <PlainButton key={valueHash} className={className} onClick={today < currentDay && disable ? () => {} : onClick} aria-labelledby={`${value.month}-${value.day}-${value.year}`}>
                 {value.day}
               </PlainButton>
             </>

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -68,12 +68,12 @@ type CalendarProps = {
   month2?: null | number;
   day2?: null | number;
   range?: boolean;
-  disable?: boolean;
+  disableFuture?: boolean;
   onChange: (year: number, month: number, day: number, range?: boolean) => void;
 };
 
 const Calendar: React.FC<CalendarProps> = ({ year = null, month = null, day = null,
-  onChange, range = false, year2, month2, day2, disable = false }) => {
+  onChange, range = false, year2, month2, day2, disableFuture = false }) => {
   const [visible, setVisible] = useState<CalendarView>(() => ({
     year: year === null ? new Date().getFullYear() : year,
     month: month === null ? new Date().getMonth() : month
@@ -186,14 +186,14 @@ const Calendar: React.FC<CalendarProps> = ({ year = null, month = null, day = nu
           const inRange = isInRange(value.year, value.month, value.day);
           const className = classnames("chq-cal--day", {
             "chq-cal--day-act": (valueHash === activeHash || valueHash === activeHash2),
-            "chq-cal--day-out": value.fill || (today < currentDay && disable),
+            "chq-cal--day-out": value.fill || (today < currentDay && disableFuture),
             "chq-cal--day-in-range": inRange
           });
 
           return (
             <>
               <div id={`${value.month}-${value.day}-${value.year}`} style={{ display: "none" }}>{monthNames[value.month]} {value.day}, {value.year}</div>
-              <PlainButton key={valueHash} className={className} onClick={today < currentDay && disable ? () => {} : onClick} aria-labelledby={`${value.month}-${value.day}-${value.year}`}>
+              <PlainButton key={valueHash} className={className} onClick={today < currentDay && disableFuture ? () => {} : onClick} aria-labelledby={`${value.month}-${value.day}-${value.year}`}>
                 {value.day}
               </PlainButton>
             </>

--- a/stories/Calendar.stories.tsx
+++ b/stories/Calendar.stories.tsx
@@ -6,7 +6,7 @@ import { Calendar } from "../src/components";
 
 type CalendarState = Pick<React.ComponentProps<typeof Calendar>, "year" | "month" | "day">;
 type ContainerProps = Pick<React.ComponentProps<typeof Calendar>, "onChange" | "range">;
-type DisableProps = Pick<React.ComponentProps<typeof Calendar>, "onChange" | "range" | "disable">;
+type DisableProps = Pick<React.ComponentProps<typeof Calendar>, "onChange" | "range" | "disableFuture">;
 
 const Container: React.FC<ContainerProps> = ({ onChange }) => {
   const [value, setValue] = useState<CalendarState>({ year: null, month: null, day: null });
@@ -62,7 +62,7 @@ const RangeContainer: React.FC<ContainerProps> = ({ onChange, range }) => {
   );
 };
 
-const RangeDisableFutureContainer: React.FC<DisableProps> = ({ onChange, range, disable }) => {
+const RangeDisableFutureContainer: React.FC<DisableProps> = ({ onChange, range, disableFuture }) => {
   const [value, setValue] = useState<CalendarState>({ year: null, month: null, day: null });
   const [value2, setValue2] = useState<CalendarState>({ year: null, month: null, day: null });
   const onCalendarChange = (year: number, month: number, day: number, isRange?: boolean) => {
@@ -95,7 +95,7 @@ const RangeDisableFutureContainer: React.FC<DisableProps> = ({ onChange, range, 
       day2={value2.day}
       onChange={onCalendarChange}
       range={range}
-      disable={disable}
+      disableFuture={disableFuture}
     />
   );
 };
@@ -108,5 +108,5 @@ storiesOf("Calendar", module)
     <RangeContainer onChange={action("onChange")} range />
   ))
   .add("disable  future", () => (
-    <RangeDisableFutureContainer onChange={action("onChange")} range disable />
+    <RangeDisableFutureContainer onChange={action("onChange")} range disableFuture />
   ));

--- a/stories/Calendar.stories.tsx
+++ b/stories/Calendar.stories.tsx
@@ -6,6 +6,7 @@ import { Calendar } from "../src/components";
 
 type CalendarState = Pick<React.ComponentProps<typeof Calendar>, "year" | "month" | "day">;
 type ContainerProps = Pick<React.ComponentProps<typeof Calendar>, "onChange" | "range">;
+type DisableProps = Pick<React.ComponentProps<typeof Calendar>, "onChange" | "range" | "disable">;
 
 const Container: React.FC<ContainerProps> = ({ onChange }) => {
   const [value, setValue] = useState<CalendarState>({ year: null, month: null, day: null });
@@ -61,10 +62,51 @@ const RangeContainer: React.FC<ContainerProps> = ({ onChange, range }) => {
   );
 };
 
+const RangeDisableFutureContainer: React.FC<DisableProps> = ({ onChange, range, disable }) => {
+  const [value, setValue] = useState<CalendarState>({ year: null, month: null, day: null });
+  const [value2, setValue2] = useState<CalendarState>({ year: null, month: null, day: null });
+  const onCalendarChange = (year: number, month: number, day: number, isRange?: boolean) => {
+    if (value.day === null) {
+      setValue({ year, month, day });
+      onChange(year, month, day, isRange);
+    } else if (isRange) {
+      if (value2.day === null) {
+        setValue2({ year, month, day });
+        onChange(year, month, day, isRange);
+      } else {
+        setValue2({ year: null, month: null, day: null });
+        setValue({ year, month, day });
+        onChange(year, month, day, isRange);
+      }
+    } else {
+      // regular calendar
+      setValue({ year, month, day });
+      onChange(year, month, day, isRange);
+    }
+  };
+
+  return (
+    <Calendar
+      year={value.year}
+      month={value.month}
+      day={value.day}
+      year2={value2.year}
+      month2={value2.month}
+      day2={value2.day}
+      onChange={onCalendarChange}
+      range={range}
+      disable={disable}
+    />
+  );
+};
+
 storiesOf("Calendar", module)
   .add("default", () => (
     <Container onChange={action("onChange")} />
   ))
   .add("range", () => (
     <RangeContainer onChange={action("onChange")} range />
+  ))
+  .add("disable  future", () => (
+    <RangeDisableFutureContainer onChange={action("onChange")} range disable />
   ));


### PR DESCRIPTION
# Pull Request

## Description

Add functionality to disable future dates on Calendar Component

Fixes [(ticket link)](https://trello.com/c/ZYcW9v5y/2372-dont-allow-the-calendar-component-to-select-dates-on-the-future)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Go to the Calendar component
- Select the disable future story
- Verify that future dates can't be selected and they appear disable
