### PR TITLE
fix: same file re-selected in ImageField and VideoField component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [20.2.2] - 2024-09-26
+
+## Changed
+
+- Fix same file re-selected in `ImageField` and `VideoField` component
+
 ## [20.2.1] - 2024-07-08
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@culturehq/components",
-  "version": "20.2.1",
+  "version": "20.2.2",
   "description": "CultureHQ's component library",
   "main": "dist/components.js",
   "types": "dist/components.d.ts",

--- a/src/components/form/ImageField.tsx
+++ b/src/components/form/ImageField.tsx
@@ -72,6 +72,9 @@ class ImageField extends React.Component<ImageFieldProps & FormState, ImageField
     const image = files && files[0];
 
     this.handleImageSelected({ editorOpen: !!image, failed: false, image: image || null });
+
+    // eslint-disable-next-line no-param-reassign
+    event.target.value = "";
   };
 
   handleImageEdited = (image: Blob, closeModal = false) => {

--- a/src/components/form/VideoField.tsx
+++ b/src/components/form/VideoField.tsx
@@ -88,6 +88,9 @@ class VideoField extends React.Component<VideoFieldProps & FormState, VideoField
     if (media?.type?.startsWith("video/")) {
       this.handleVideoSelected(media, null, null, !notReturnMetadata);
     }
+
+    // eslint-disable-next-line no-param-reassign
+    event.target.value = "";
   };
 
   handleVideoEdited = (output: Blob, thumb: Blob) => {


### PR DESCRIPTION
# Pull Request

## Description

fix: same file re-selected in ImageField and VideoField component

Fixes  ([ticket link](https://trello.com/c/rLGGSIo4))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Try to select and re-select the same field using `VideoField` and `ImageField`.