### PR TITLE
fix: visibility of placeholder on select field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [20.4.1] - 2025-04-07
+
+## Changed
+
+- Fix the placeholder visibility of the select field
+
 ## [20.4.0] - 2025-03-13
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@culturehq/components",
-  "version": "20.4.0",
+  "version": "20.4.1",
   "description": "CultureHQ's component library",
   "main": "dist/components.js",
   "types": "dist/components.d.ts",

--- a/src/components/form/select/SelectFieldMultiValue.tsx
+++ b/src/components/form/select/SelectFieldMultiValue.tsx
@@ -27,12 +27,12 @@ const SelectFieldMultiValueBadge: React.FC<SelectFieldMultiValueBadgeProps> = ({
     if (actionButtonCallback) {
       return (
         <div className="option-group">
-          <Badge aria-label={`Unselect ${label}`} icon="close" onClick={onClick}>
+          <Badge id="option-tag" aria-label={`Unselect ${label}`} icon="close" onClick={onClick}>
             {label.length > MAX_LENGHT ? `${label.substring(0, MAX_LENGHT)}...` : label}
             {" "}
             <Icon icon={categoryIcon} className="category-icon" />
           </Badge>
-          <PlainButton aria-label={actionAriaLabel} className="option-action" onClick={() => { actionButtonCallback(value, category, label); }}>
+          <PlainButton id="option-action" aria-label={actionAriaLabel} className="option-action" onClick={() => { actionButtonCallback(value, category, label); }}>
             <Icon icon="plus" />
           </PlainButton>
           {" "}
@@ -42,7 +42,7 @@ const SelectFieldMultiValueBadge: React.FC<SelectFieldMultiValueBadgeProps> = ({
 
     return (
       <>
-        <Badge aria-label={`Unselect ${label}`} icon="close" onClick={onClick}>
+        <Badge id="option-tag" aria-label={`Unselect ${label}`} icon="close" onClick={onClick}>
           {label.length > MAX_LENGHT ? `${label.substring(0, MAX_LENGHT)}...` : label}
           {" "}
           <Icon icon={categoryIcon} className="category-icon" />
@@ -56,8 +56,8 @@ const SelectFieldMultiValueBadge: React.FC<SelectFieldMultiValueBadgeProps> = ({
     if (actionButtonCallback) {
       return (
         <div className="option-group">
-          <Badge aria-label={`Unselect ${label}`} icon="close" onClick={onClick}>{label}</Badge>
-          <PlainButton aria-label={actionAriaLabel} className="option-action" onClick={() => { actionButtonCallback(value, category, label); }}>
+          <Badge id="option-tag" aria-label={`Unselect ${label}`} icon="close" onClick={onClick}>{label}</Badge>
+          <PlainButton id="option-action" aria-label={actionAriaLabel} className="option-action" onClick={() => { actionButtonCallback(value, category, label); }}>
             <Icon icon="plus" />
           </PlainButton>
           {" "}
@@ -67,7 +67,7 @@ const SelectFieldMultiValueBadge: React.FC<SelectFieldMultiValueBadgeProps> = ({
 
     return (
       <>
-        <Badge aria-label={`Unselect ${label}`} icon="close" onClick={onClick}>
+        <Badge id="option-tag" aria-label={`Unselect ${label}`} icon="close" onClick={onClick}>
           {label.length > MAX_LENGHT ? `${label.substring(0, MAX_LENGHT)}...` : label}
         </Badge>
         {" "}
@@ -75,11 +75,14 @@ const SelectFieldMultiValueBadge: React.FC<SelectFieldMultiValueBadgeProps> = ({
     );
   }
 
-  return <><Badge icon="close" /></>;
+  return <><Badge id="option-tag" icon="close" /></>;
 };
 
 type SelectFieldMultiValueProps = Pick<SelectFieldPassedProps, "ariaLabel" | "disabled" | "imageIconPath" | "display" | "inputRef" | "name" | "onChange" | "onClose" | "onDeselect" | "onOpen" | "open" | "options" | "onSelected" | "onUnselected" | "placeholder" | "removePlacholder"> & {
   value: any;
+  placeholderIsVisible: boolean;
+  onInputBlur: (event:any) => void;
+  onInpuFocus: () => void;
 };
 
 class SelectFieldMultiValue extends React.Component<
@@ -132,7 +135,7 @@ class SelectFieldMultiValue extends React.Component<
   render(): React.ReactElement {
     const {
       ariaLabel, disabled, display, imageIconPath, inputRef, name, onChange,
-      onDeselect, onOpen, open, onSelected, onUnselected, placeholder, removePlacholder
+      onDeselect, onOpen, open, placeholder, onInpuFocus, onInputBlur, placeholderIsVisible
     } = this.props;
 
     const className = classnames("chq-ffd--ctrl", { "chq-ffd--ctrl-fc": open });
@@ -175,11 +178,11 @@ class SelectFieldMultiValue extends React.Component<
           ref={inputRef}
           onChange={onChange}
           onKeyDown={this.handleKeyDown}
-          onFocus={onSelected}
-          onBlur={onUnselected}
+          onFocus={onInpuFocus}
+          onBlur={onInputBlur}
           value={display}
         />
-        {placeholder && !display && !(removePlacholder && currentOptions.length >= 2) && <span className="chq-ffd--sl--place">{placeholder}</span>}
+        {placeholderIsVisible && <span id="sl-placeholder" className="chq-ffd--sl--place">{placeholder}</span>}
         <SelectFieldCaret open={open} />
       </div>
     );

--- a/src/components/form/select/SelectFieldOptions.tsx
+++ b/src/components/form/select/SelectFieldOptions.tsx
@@ -25,6 +25,7 @@ type SelectFieldOptionProps = Pick<SelectFieldPassedProps, "onDeselect" | "onSel
   current: boolean;
   option: SelectOption;
   tabIndex: number;
+  created: boolean;
 };
 
 const SelectFieldOption: React.FC<SelectFieldOptionProps> = React.memo(({
@@ -32,7 +33,8 @@ const SelectFieldOption: React.FC<SelectFieldOptionProps> = React.memo(({
   option,
   onDeselect,
   onSelect,
-  tabIndex
+  tabIndex,
+  created
 }) => {
   const { label, value, icon, category } = option;
   const onClick = () => (
@@ -40,7 +42,7 @@ const SelectFieldOption: React.FC<SelectFieldOptionProps> = React.memo(({
   );
 
   return (
-    <PlainButton aria-current={current} aria-label={`${current ? "Unselect" : "Select"} ${label}${category ? ` - ${category}` : ""}`} onClick={onClick} tabIndex={tabIndex}>
+    <PlainButton id={created ? "create-field-option" : "select-field-option"} className="chq-ffd--sl--opts-chq-pbn" aria-current={current} aria-label={`${current ? "Unselect" : "Select"} ${label}${category ? ` - ${category}` : ""}`} onClick={onClick} tabIndex={tabIndex}>
       {icon && <><Icon className="option-icon" icon={icon} />{" "}</>}
       {label}
       {category && <span className="option-category">{" "}({category})</span>}
@@ -99,6 +101,7 @@ const SelectFieldOptions: React.FC<SelectFieldOptionsProps> = React.memo(({
               onSelect={onSelect}
               option={{ label: `${creatableLabel?.length > 0 ? creatableLabel : "Create option"}: ${display}`, value: display }}
               tabIndex={open ? 0 : -1}
+              created
             />
           )}
           {filteredOptions.map(option => (
@@ -109,6 +112,7 @@ const SelectFieldOptions: React.FC<SelectFieldOptionsProps> = React.memo(({
               onSelect={onSelect}
               option={option}
               tabIndex={open ? 0 : -1}
+              created={false}
             />
           ))}
           {!createOption && (filteredOptions?.length === 0) && (

--- a/src/styles/components/_select-field.scss
+++ b/src/styles/components/_select-field.scss
@@ -57,13 +57,9 @@
     outline: none;
     padding: 0;
     width: 1px;
-
-    &:focus {
+    
+    &__focus {
       width: auto;
-
-      & + .chq-ffd--sl--place {
-        display: none;
-      }
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Description

Maintain the placeholder visibility when deleting tags on the select field. **V.20.4.1**

Fixes [(ticket link)](https://trello.com/c/zvLIIWRC/3123-select-tags-component-issue-deleting-tags)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Go to the select filed stories
- Add tags
- Verify that when deleting tags, the placeholder doesn't change it's visibility
- Verify that select fields with autofocus are working properly too
