### PR TITLE
feat: add prop oncancel to image editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [20.8.0] - 2025-06-17
+
+### Changed
+
+- Add new property to imageEditor to cancel crop changes
+- Add property to imageField to cancel crop changes
+- Unit test update
+
 ## [Unreleased]
 
 ## [20.7.0] - 2025-05-22

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@culturehq/components",
-  "version": "20.7.0",
+  "version": "20.8.0",
   "description": "CultureHQ's component library",
   "main": "dist/components.js",
   "types": "dist/components.d.ts",

--- a/src/components/form/ImageField.tsx
+++ b/src/components/form/ImageField.tsx
@@ -16,6 +16,7 @@ type ImageFieldProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, Hijacke
   aspectRatio?: number;
   autoFocus?: boolean;
   backgroundIcon?: IconName;
+  clickOutsideCancel?: boolean;
   imageAsBackground?: boolean;
   buttonLabel?: string;
   children: React.ReactNode;
@@ -150,9 +151,9 @@ class ImageField extends React.Component<ImageFieldProps & FormState, ImageField
 
   render() {
     const {
-      aspectRatio, autoFocus, backgroundIcon, imageAsBackground, buttonLabel, children, className,
-      disabledStates, errors, name, onChange, onError, onFieldDisabledChange, asButtonView,
-      onFormChange, progress, required, submitted, submitting, validator, value, values,
+      aspectRatio, autoFocus, backgroundIcon, clickOutsideCancel, imageAsBackground, buttonLabel,
+      children, className, disabledStates, errors, name, onChange, onError, onFieldDisabledChange,
+      asButtonView, onFormChange, progress, required, submitted, submitting, validator, value, values,
       icon, registerModal, ...props
     } = this.props;
 
@@ -206,6 +207,7 @@ class ImageField extends React.Component<ImageFieldProps & FormState, ImageField
                   image={preview}
                   onEdit={this.handleImageEdited}
                   onFailure={this.handleImageFailure}
+                  clickOutsideCancel={clickOutsideCancel}
                 />
               </ModalDialog.Body>
             </ModalDialog>
@@ -286,6 +288,7 @@ class ImageField extends React.Component<ImageFieldProps & FormState, ImageField
                   image={preview}
                   onEdit={this.handleImageEdited}
                   onFailure={this.handleImageFailure}
+                  clickOutsideCancel={clickOutsideCancel}
                 />
               </ModalDialog.Body>
             </ModalDialog>

--- a/stories/form/ImageField.stories.tsx
+++ b/stories/form/ImageField.stories.tsx
@@ -51,6 +51,7 @@ storiesOf("Form/ImageField", module)
     );
   })
   .add("asButton", () => <Container name="image" asButtonView><></></Container>)
+  .add("cancelOption", () => <Container name="image" clickOutsideCancel>Image</Container>)
   .add("validator", () => {
     const validator = (value: ImageFieldValue) => {
       if (value instanceof File && value.type === "image/png") {


### PR DESCRIPTION
Pull Request
Description
Add prop cancel to image editor
field. V.20.8.0

Fixes (https://trello.com/c/7HGZToZq/3305-qa-bug-found-thumbnail-crop-prod-staging-jimmy)

Type of change
 [X] Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
Go to Crop Image
When the onCancel property is passed to the ImageEditor from CropImage, verify that the changes are canceled when I click outside the crop area.